### PR TITLE
🩹 Add `docker-compose` network for local dev

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -6,4 +6,4 @@ LAVALINK_PASSWORD=/secrets/lavalink-password
 SOCKET_KEY=/secrets/socket-key
 SPOTIFY_CLIENT_ID=/secrets/spotify-client-id
 SPOTIFY_CLIENT_SECRET=/secrets/spotify-client-secret
-WEBSITE_BASE_URL=https://staging.mocbot.masterofcubesau.com
+WEBSITE_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ in an isolated environment using Docker.
    | `api-key` | The API key to connect to MOCBOT API. Assuming you are running the `MOCBOT-API` repo locally without changes, the default APIKey set in that repo is `test`. |
    | `bot-token` | The token of the Discord bot |
    | `lavalink-password` | The password for the Lavalink server. Take note of this to put in the Lavalink config as well. |
-   | `socket-key` | The key that will allow other services to connect to MOCBOT's socket. |
+   | `socket-key` | The key that will allow other services to connect to MOCBOT's socket. This should be the SHA256 hash of the intended key. |
    | `spotify-client-id` | The client ID for the Spotify API. |
    | `spotify-client-secret` | The client secret for the Spotify API. |
 3. Copy [`lavalink/application.template.yaml`](./lavalink/application.template.yaml) to `lavalink/application.yaml.local`, and replace any template values with your own. Ensure that

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     env_file:
       - ./.env.local
     networks:
+      - bot
       - lavalink
       - mocbot-api_api
   lavalink:
@@ -19,6 +20,7 @@ services:
       - lavalink
 
 networks:
+  bot:
+  lavalink:
   mocbot-api_api:
     external: true
-  lavalink:


### PR DESCRIPTION
Adding extra bot network for website to connect to during local development + other minor changes.