### PR TITLE
✨ Add support for changing voice channels + other changes

### DIFF
--- a/lavalink/application.template.yaml
+++ b/lavalink/application.template.yaml
@@ -3,7 +3,7 @@ server:
   address: 0.0.0.0
 lavalink:
   plugins:
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.13.3"
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.13.4"
       snapshot: false
     - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.7.3"
       repository: "https://maven.lavalink.dev/releases"

--- a/lib/cogs/Verification.py
+++ b/lib/cogs/Verification.py
@@ -98,6 +98,7 @@ class Verification(commands.Cog):
         member_role_ids = [role.id for role in member.roles]
         verification_role_id = settings.get("VerificationRoleID")
         lockdown_role_id = settings.get("LockdownRoleID")
+        admin = kwargs.get("admin")
 
         if (int(verification_role_id) in member_role_ids or int(lockdown_role_id) in member_role_ids) and len(
             member_role_ids
@@ -140,7 +141,7 @@ class Verification(commands.Cog):
                             embed=Verification.bot.create_embed(
                                 "MOCBOT VERIFICATION",
                                 f"You have been successfully verified in **{member.guild}**"
-                                f"{' by {}'.format(kwargs.get('admin').mention) if kwargs.get('admin') != None else ''}"
+                                f"{' by {}'.format(admin.mention) if admin is not None else ''}"
                                 ". Enjoy your stay!",
                                 None,
                             )


### PR DESCRIPTION
This PR introduces several changes and fixes:
- Adding support to allow MOCBOT to continue functioning after switching voice channels
- Adding support for MOCBOT to automatically disconnect from the call if the last person in a call has disconnected
- Reshuffling the updating logic in the loop and autoplay functions to ensure that the now playing embed is updated at roughly the same time as the message is sent. Previously, the embed would only update *after* the response message had been deleted, which wasn't ideal.
- Bumping the YouTube source plugin in Lavalink to the latest version
- Fixing minor linting issues