### PR TITLE
✏️ Fix missing Spotify credentials

### DIFF
--- a/lavalink/application.template.yaml
+++ b/lavalink/application.template.yaml
@@ -55,7 +55,7 @@ plugins:
       youtube: false
     spotify:
       clientId: ${SPOTIFY_CLIENT_ID}
-      clientSecret: ${SPOTIFY_SECRET}
+      clientSecret: ${SPOTIFY_CLIENT_SECRET}
       countryCode: "AU"
     youtube:
       countryCode: "AU"


### PR DESCRIPTION
Spotify secret credentials were missing from the config in deployment due to a mismatch in the keys.