### PR TITLE
🩹 Replace `yt-cipher` image and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ in an isolated environment using Docker.
    | `bot-token` | The token of the Discord bot |
    | `lavalink-password` | The password for the Lavalink server. Take note of this to put in the Lavalink config as well. |
    | `socket-key` | The key that will allow other services to connect to MOCBOT's socket. This should be the SHA256 hash of the intended key. |
-   | `spotify-client-id` | The client ID for the Spotify API. |
-   | `spotify-client-secret` | The client secret for the Spotify API. |
 3. Copy [`lavalink/application.template.yaml`](./lavalink/application.template.yaml) to `lavalink/application.yaml.local`, and replace any template values with your own. Ensure that
    `lavalink-password` is the same as the one in `.local-secrets/lavalink-password`.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - lavalink
       - yt-cipher
   yt-cipher:
-    image: mocbotau/cloud:yt-cipher
+    image: ghcr.io/kikkia/yt-cipher:master
     restart: unless-stopped
     networks:
       - yt-cipher

--- a/infra/values.yaml
+++ b/infra/values.yaml
@@ -30,7 +30,7 @@ deployments:
     service:
       port: 65535
   - name: "yt-cipher"
-    image: "${DOCKERHUB_USERNAME}/${DOCKERHUB_REPO}:yt-cipher"
+    image: "ghcr.io/kikkia/yt-cipher:master"
     service:
       port: 8001
 


### PR DESCRIPTION
Replace the `yt-cipher` image that was using our own custom built Docker image temporarily while the official image was being fixed. Now that it is indeed fixed, we can use their image instead to stay up to date.

Also removing the Spotify client secrets note from the README as they are no longer needed inside of the `.local-secrets` folder.