### PR TITLE
fix: general bugs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     ports:
       - "65535:65535"
   lavalink:
-    image: ghcr.io/lavalink-devs/lavalink:4.2.1-alpine
+    image: ghcr.io/lavalink-devs/lavalink:4.2.2-alpine
     restart: unless-stopped
     volumes:
       - ./lavalink/application.yaml.local:/opt/Lavalink/application.yaml:ro

--- a/infra/values.yaml.gotmpl
+++ b/infra/values.yaml.gotmpl
@@ -51,7 +51,7 @@ deployments:
 
 statefulSets:
   - name: "lavalink"
-    image: "ghcr.io/lavalink-devs/lavalink:4.2.1-alpine"
+    image: "ghcr.io/lavalink-devs/lavalink:4.2.2-alpine"
     updateStrategy: "OnDelete"
     config:
       fileVariable: "lavalinkConfig"

--- a/lavalink/application.template.yaml
+++ b/lavalink/application.template.yaml
@@ -3,9 +3,9 @@ server:
   address: 0.0.0.0
 lavalink:
   plugins:
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.18.0"
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.18.1"
       snapshot: false
-    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.8.1"
+    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.8.2"
       repository: "https://maven.lavalink.dev/releases"
       snapshot: false
   server:

--- a/lib/cogs/Music.py
+++ b/lib/cogs/Music.py
@@ -147,26 +147,37 @@ class Music(commands.Cog):
     @commands.Cog.listener()
     async def on_voice_state_update(self, member: Member, before: VoiceState, after: VoiceState):
         """Handle voice state updates"""
-        # If there are no members left in the voice channel, disconnect the bot
-        if member.id != self.bot.user.id:
-            if after.channel is None and before.channel is not None and len(before.channel.members) == 1:
-                # prefer to emit event so all listeners get notified
-                await self.service.emitter.emit(
-                    "player_stopped",
-                    {"player": self.service.get_player_by_guild(before.channel.guild.id), "disconnect": True},
-                )
+        if member.id == self.bot.user.id:
+            # Handle bot moving to new channel gracefully
+            if before.channel and after.channel and before.channel != after.channel:
+                guild_id = member.guild.id
+                player = self.service.get_player_by_guild(guild_id)
+
+                if player and player.is_connected:
+                    if hasattr(member.guild.voice_client, "channel"):
+                        member.guild.voice_client.channel = after.channel
+
+                await self.service.emitter.emit("player_state_update", player)
             return
 
-        # Handle bot moving to new channel gracefully
-        if before.channel and after.channel and before.channel != after.channel:
-            guild_id = member.guild.id
-            player = self.service.get_player_by_guild(guild_id)
+        # Connects or moves to a new channel should not trigger disconnect logic
+        if after.channel is not None or before.channel is None:
+            return
 
-            if player and player.is_connected:
-                if hasattr(member.guild.voice_client, "channel"):
-                    member.guild.voice_client.channel = after.channel
+        guild = before.channel.guild
 
-            await self.service.emitter.emit("player_state_update", player)
+        # Check if bot is connected to the channel the user left, if not ignore
+        if not guild.voice_client or guild.voice_client.channel != before.channel:
+            return
+
+        # Only disconnect if only the bot remains
+        if len(before.channel.members) != 1:
+            return
+
+        await self.service.emitter.emit(
+            "player_stopped",
+            {"player": self.service.get_player_by_guild(guild.id), "disconnect": True},
+        )
 
     async def update_now_playing(self, guild: Guild, player: DefaultPlayer):
         """Update the now playing message for a guild"""
@@ -730,7 +741,7 @@ class Music(commands.Cog):
             queued_msg = (
                 f"Queued **{len(selected_uris)}** tracks from **{mode}** mode."
             )
-        
+
         if not result["was_playing"]:
             player = self.service.get_player_by_guild(interaction.guild.id)
             autoplay_mode = "Recommended" if recommended else "Related"

--- a/lib/music/MusicLyrics.py
+++ b/lib/music/MusicLyrics.py
@@ -4,6 +4,10 @@ from utils.Pagination import BasePaginationMenu, BasePaginationSource
 class LyricsMenu(BasePaginationMenu):
     """Lyrics pagination menu that extends the base pagination functionality"""
 
+    def __init__(self, source, interaction):
+        """Initialize lyrics menu with no timeout"""
+        super().__init__(source, interaction, timeout=None)
+
     async def send_initial_message(self):
         """Override to use followup for lyrics since interaction might already be responded to"""
         page = await self._source.get_page(0)

--- a/lib/music/MusicService.py
+++ b/lib/music/MusicService.py
@@ -567,13 +567,21 @@ class MusicService:
         asyncio.create_task(self.emitter.emit("player_state_update", player))
 
     async def shuffle(self, guild_id: int, user_id: int) -> None:
-        """Shuffle the current queue."""
+        """Shuffle the current queue, keeping tracks with position at the top as they are being resumed."""
         player = await self.ensure_voice(guild_id, user_id)
 
         if len(player.queue) < 2:
             raise UserError("You need at least 2 tracks in the queue to shuffle.")
 
-        random.shuffle(player.queue)
+        tracks_with_position = [track for track in player.queue if track.position > 0]
+        tracks_without_position = [track for track in player.queue if track.position == 0]
+
+        random.shuffle(tracks_without_position)
+
+        player.queue.clear()
+        player.queue.extend(tracks_with_position)
+        player.queue.extend(tracks_without_position)
+
         asyncio.create_task(self.emitter.emit("queue_update", player))
 
     async def remove(self, guild_id: int, user_id: int, start: int, end: int = None) -> int | SingleTrackResponse:

--- a/lib/music/containers/queue_display.py
+++ b/lib/music/containers/queue_display.py
@@ -59,6 +59,11 @@ class QueueContainer(PaginatedContainer):
             track_num = idx + 1
             duration = format_duration(track.duration) if not track.stream else "LIVE STREAM"
             requester = f"<@{track.requester}>" if track.requester else self.bot.user.mention
+
+            if hasattr(track, 'position') and track.position > 0:
+                position_formatted = format_duration(track.position)
+                duration = f"{position_formatted}/{duration}"
+
             line_text = f"**{track_num}**. [{track.title}]({track.uri})\n-# {track.author} • {duration} • {requester}"
 
             delete_button = discord.ui.Button(

--- a/poetry.lock
+++ b/poetry.lock
@@ -826,13 +826,13 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "lavalink"
-version = "5.10.0"
+version = "5.11.0"
 description = "A Lavalink WebSocket & API wrapper built around coverage, reliability and performance."
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "lavalink-5.10.0.tar.gz", hash = "sha256:6b364726a4db753dbe398ce4343b7eee20368b84bb6b0092156d08e0b8caf64f"},
+    {file = "lavalink-5.11.0.tar.gz", hash = "sha256:6e3c33614464a4f68e366039fc1e3f256b5d0e26c637c8748a1b61345e1dfa13"},
 ]
 
 [package.dependencies]
@@ -1498,4 +1498,4 @@ requests = ">=2.22"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "c510eaf91261ee1839364fb0b93656faafd7b8d45dc9fa77293f9d4a129c0392"
+content-hash = "1b23cb9290b136b38a5d2858565f9cdb8ec9ad0e7f43c8f64c50aa882f014ce1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ python = "^3.10"
 discord-ext-menus = "1.1.0"
 discord-py = {version = "2.7.1", extras = ["voice"]}
 expiringdict = "1.2.2"
-lavalink = "5.10.0"
+lavalink = "5.11.0"
 pillow = "9.3.0"
 python-socketio = "5.11.0"
 pyyaml = "6.0.1"


### PR DESCRIPTION
* closes #130 - music lyrics no longer have a timeout to delete
* closes #110 - mocbot should no longer disconnect when another channel has one member remaining
* closes #100 - playnow songs no longer get shuffled as well, they remain at the top of the queue
* fix regression, missing resume track position in queue display
* bump lavalink + plugins to latest versions
* bump lavalink py version